### PR TITLE
✨ feat: create/update resume tools import map

### DIFF
--- a/.xmcp/adapter/index.js
+++ b/.xmcp/adapter/index.js
@@ -9,6 +9,17 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
+/***/ "../src/tools/create-resume.ts":
+/*!***************************************************!*\
+  !*** external "../../src/tools/create-resume.ts" ***!
+  \***************************************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("../../src/tools/create-resume.ts");
+
+/***/ }),
+
 /***/ "../src/tools/delete-resume.ts":
 /*!***************************************************!*\
   !*** external "../../src/tools/delete-resume.ts" ***!
@@ -42,6 +53,17 @@ module.exports = require("../../src/tools/list-resumes.ts");
 
 /***/ }),
 
+/***/ "../src/tools/update-resume.ts":
+/*!***************************************************!*\
+  !*** external "../../src/tools/update-resume.ts" ***!
+  \***************************************************/
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("../../src/tools/update-resume.ts");
+
+/***/ }),
+
 /***/ "./.xmcp/adapter-nextjs.js":
 /*!*********************************!*\
   !*** ./.xmcp/adapter-nextjs.js ***!
@@ -59,7 +81,7 @@ eval("{/* provided dependency */ var INJECTED_TOOLS = __webpack_require__(/*! ./
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 "use strict";
-eval("{__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   prompts: () => (/* binding */ prompts),\n/* harmony export */   resources: () => (/* binding */ resources),\n/* harmony export */   tools: () => (/* binding */ tools)\n/* harmony export */ });\n\nconst tools = {\n\"src/tools/list-resumes.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/list-resumes.ts */ \"../src/tools/list-resumes.ts\", 23)),\n\"src/tools/get-resume.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/get-resume.ts */ \"../src/tools/get-resume.ts\", 23)),\n\"src/tools/delete-resume.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/delete-resume.ts */ \"../src/tools/delete-resume.ts\", 23)),\n};\n\nconst prompts = {\n\n};\n\nconst resources = {\n\n};\n\n\n//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi8ueG1jcC9pbXBvcnQtbWFwLmpzIiwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBIiwic291cmNlcyI6WyJ3ZWJwYWNrOi8vTmV4dC5qcyB3aXRoIEFkYXB0ZXIvLi8ueG1jcC9pbXBvcnQtbWFwLmpzPzY2MTIiXSwic291cmNlc0NvbnRlbnQiOlsiXG5leHBvcnQgY29uc3QgdG9vbHMgPSB7XG5cInNyYy90b29scy9saXN0LXJlc3VtZXMudHNcIjogKCkgPT4gaW1wb3J0KFwiLi4vc3JjL3Rvb2xzL2xpc3QtcmVzdW1lcy50c1wiKSxcblwic3JjL3Rvb2xzL2dldC1yZXN1bWUudHNcIjogKCkgPT4gaW1wb3J0KFwiLi4vc3JjL3Rvb2xzL2dldC1yZXN1bWUudHNcIiksXG5cInNyYy90b29scy9kZWxldGUtcmVzdW1lLnRzXCI6ICgpID0+IGltcG9ydChcIi4uL3NyYy90b29scy9kZWxldGUtcmVzdW1lLnRzXCIpLFxufTtcblxuZXhwb3J0IGNvbnN0IHByb21wdHMgPSB7XG5cbn07XG5cbmV4cG9ydCBjb25zdCByZXNvdXJjZXMgPSB7XG5cbn07XG5cblxuIl0sIm5hbWVzIjpbXSwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./.xmcp/import-map.js\n\n}");
+eval("{__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   prompts: () => (/* binding */ prompts),\n/* harmony export */   resources: () => (/* binding */ resources),\n/* harmony export */   tools: () => (/* binding */ tools)\n/* harmony export */ });\n\nconst tools = {\n\"src/tools/delete-resume.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/delete-resume.ts */ \"../src/tools/delete-resume.ts\", 23)),\n\"src/tools/get-resume.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/get-resume.ts */ \"../src/tools/get-resume.ts\", 23)),\n\"src/tools/list-resumes.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/list-resumes.ts */ \"../src/tools/list-resumes.ts\", 23)),\n\"src/tools/create-resume.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/create-resume.ts */ \"../src/tools/create-resume.ts\", 23)),\n\"src/tools/update-resume.ts\": () => Promise.resolve(/*! import() */).then(__webpack_require__.t.bind(__webpack_require__, /*! ../src/tools/update-resume.ts */ \"../src/tools/update-resume.ts\", 23)),\n};\n\nconst prompts = {\n\n};\n\nconst resources = {\n\n};\n\n\n//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiLi8ueG1jcC9pbXBvcnQtbWFwLmpzIiwibWFwcGluZ3MiOiI7Ozs7OztBQUFBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQSIsInNvdXJjZXMiOlsid2VicGFjazovL05leHQuanMgd2l0aCBBZGFwdGVyLy4vLnhtY3AvaW1wb3J0LW1hcC5qcz82NjEyIl0sInNvdXJjZXNDb250ZW50IjpbIlxuZXhwb3J0IGNvbnN0IHRvb2xzID0ge1xuXCJzcmMvdG9vbHMvZGVsZXRlLXJlc3VtZS50c1wiOiAoKSA9PiBpbXBvcnQoXCIuLi9zcmMvdG9vbHMvZGVsZXRlLXJlc3VtZS50c1wiKSxcblwic3JjL3Rvb2xzL2dldC1yZXN1bWUudHNcIjogKCkgPT4gaW1wb3J0KFwiLi4vc3JjL3Rvb2xzL2dldC1yZXN1bWUudHNcIiksXG5cInNyYy90b29scy9saXN0LXJlc3VtZXMudHNcIjogKCkgPT4gaW1wb3J0KFwiLi4vc3JjL3Rvb2xzL2xpc3QtcmVzdW1lcy50c1wiKSxcblwic3JjL3Rvb2xzL2NyZWF0ZS1yZXN1bWUudHNcIjogKCkgPT4gaW1wb3J0KFwiLi4vc3JjL3Rvb2xzL2NyZWF0ZS1yZXN1bWUudHNcIiksXG5cInNyYy90b29scy91cGRhdGUtcmVzdW1lLnRzXCI6ICgpID0+IGltcG9ydChcIi4uL3NyYy90b29scy91cGRhdGUtcmVzdW1lLnRzXCIpLFxufTtcblxuZXhwb3J0IGNvbnN0IHByb21wdHMgPSB7XG5cbn07XG5cbmV4cG9ydCBjb25zdCByZXNvdXJjZXMgPSB7XG5cbn07XG5cblxuIl0sIm5hbWVzIjpbXSwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./.xmcp/import-map.js\n\n}");
 
 /***/ }),
 

--- a/.xmcp/import-map.js
+++ b/.xmcp/import-map.js
@@ -1,8 +1,10 @@
 
 export const tools = {
-"src/tools/list-resumes.ts": () => import("../src/tools/list-resumes.ts"),
-"src/tools/get-resume.ts": () => import("../src/tools/get-resume.ts"),
 "src/tools/delete-resume.ts": () => import("../src/tools/delete-resume.ts"),
+"src/tools/get-resume.ts": () => import("../src/tools/get-resume.ts"),
+"src/tools/list-resumes.ts": () => import("../src/tools/list-resumes.ts"),
+"src/tools/create-resume.ts": () => import("../src/tools/create-resume.ts"),
+"src/tools/update-resume.ts": () => import("../src/tools/update-resume.ts"),
 };
 
 export const prompts = {

--- a/src/lib/db/resume.ts
+++ b/src/lib/db/resume.ts
@@ -151,17 +151,20 @@ export async function getResume(id: string) {
   return {
     ...resume,
     workHistory: work.map((w) => ({
+      id: w.id,
       companyName: w.companyName,
       role: w.role,
       dateOfWork: w.dateOfWork,
       description: w.description,
     })),
     projects: proj.map((p) => ({
+      id: p.id,
       projectName: p.projectName,
       projectUrl: p.projectUrl,
       projectDescription: p.projectDescription,
     })),
     achievements: ach.map((a) => ({
+      id: a.id,
       achievementName: a.achievementName,
       achievementUrl: a.achievementUrl,
       achievementDescription: a.achievementDescription,

--- a/src/tools/create-resume.ts
+++ b/src/tools/create-resume.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+import { requireApiKey } from "../lib/api-key-validator";
+import { createResume, getResume } from "../lib/db/resume";
+
+// Define schemas for nested objects
+const workHistorySchema = z.object({
+  companyName: z.string().describe("Company name"),
+  role: z.string().describe("Job role/position"),
+  dateOfWork: z.string().describe("Date range of employment (e.g. 'Jan 2020 - Dec 2022')"),
+  description: z.string().describe("Job responsibilities and achievements"),
+});
+
+const projectSchema = z.object({
+  projectName: z.string().describe("Project name"),
+  projectUrl: z.string().optional().describe("Project URL (optional)"),
+  projectDescription: z.string().describe("Project description"),
+});
+
+const achievementSchema = z.object({
+  achievementName: z.string().describe("Achievement name"),
+  achievementUrl: z.string().optional().describe("Achievement URL (optional)"),
+  achievementDescription: z.string().describe("Achievement description"),
+});
+
+// Define the schema for tool parameters
+export const schema = {
+  name: z.string().min(1).describe("Full name (required)"),
+  title: z.string().optional().default("Untitled Resume").describe("Resume title (default: 'Untitled Resume')"),
+  email: z.string().email().optional().default("").describe("Email address (optional but recommended)"),
+  github: z.string().url().optional().describe("GitHub profile URL (optional)"),
+  description: z.string().optional().describe("Professional summary (optional)"),
+  workHistory: z.array(workHistorySchema).optional().default([]).describe("Array of work history entries (optional)"),
+  projects: z.array(projectSchema).optional().default([]).describe("Array of project entries (optional)"),
+  achievements: z.array(achievementSchema).optional().default([]).describe("Array of achievement entries (optional)"),
+};
+
+// Define tool metadata
+export const metadata: ToolMetadata = {
+  name: "create-resume",
+  description: "Create a new resume with work history, projects, and achievements. Only name is required, all other fields are optional.",
+  annotations: {
+    title: "Create Resume",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+  },
+};
+
+// Tool implementation with API key validation
+export default requireApiKey(async (params: InferSchema<typeof schema>, validation) => {
+  try {
+    // Filter out empty entries from arrays (matching frontend behavior)
+    const filteredWorkHistory = (params.workHistory || []).filter((entry) =>
+      entry.companyName.trim().length > 0 ||
+      entry.role.trim().length > 0 ||
+      entry.dateOfWork.trim().length > 0 ||
+      entry.description.trim().length > 0
+    );
+
+    const filteredProjects = (params.projects || []).filter((entry) =>
+      entry.projectName.trim().length > 0 ||
+      (entry.projectUrl && entry.projectUrl.trim().length > 0) ||
+      entry.projectDescription.trim().length > 0
+    );
+
+    const filteredAchievements = (params.achievements || []).filter((entry) =>
+      entry.achievementName.trim().length > 0 ||
+      (entry.achievementUrl && entry.achievementUrl.trim().length > 0) ||
+      entry.achievementDescription.trim().length > 0
+    );
+
+    // Create the resume
+    const resumeId = await createResume({
+      userId: validation.userId!,
+      title: params.title || "Untitled Resume",
+      name: params.name,
+      email: params.email || "",
+      github: params.github && params.github.trim().length > 0 ? params.github : undefined,
+      description: params.description && params.description.trim().length > 0 ? params.description : undefined,
+      workHistory: filteredWorkHistory,
+      projects: filteredProjects,
+      achievements: filteredAchievements,
+    });
+
+    // Fetch the complete resume to return to the user
+    const createdResume = await getResume(resumeId);
+
+    // Return success message with the created resume
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: true,
+              message: "Resume created successfully",
+              resumeId,
+              resume: createdResume,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  } catch (error: any) {
+    // Handle any errors during resume creation
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              error: "Failed to create resume",
+              details: error?.message || "Unknown error",
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  }
+});
+

--- a/src/tools/update-resume.ts
+++ b/src/tools/update-resume.ts
@@ -1,0 +1,154 @@
+import { z } from "zod";
+import { type InferSchema, type ToolMetadata } from "xmcp";
+import { requireApiKey } from "../lib/api-key-validator";
+import { getResume, updateResume } from "../lib/db/resume";
+
+// Define schemas for nested objects
+const workHistorySchema = z.object({
+  companyName: z.string().describe("Company name"),
+  role: z.string().describe("Job role/position"),
+  dateOfWork: z.string().describe("Date range of employment (e.g. 'Jan 2020 - Dec 2022')"),
+  description: z.string().describe("Job responsibilities and achievements"),
+});
+
+const projectSchema = z.object({
+  projectName: z.string().describe("Project name"),
+  projectUrl: z.string().optional().describe("Project URL (optional)"),
+  projectDescription: z.string().describe("Project description"),
+});
+
+const achievementSchema = z.object({
+  achievementName: z.string().describe("Achievement name"),
+  achievementUrl: z.string().optional().describe("Achievement URL (optional)"),
+  achievementDescription: z.string().describe("Achievement description"),
+});
+
+// Define the schema for tool parameters
+export const schema = {
+  resumeId: z.string().uuid().describe("The UUID of the resume to update"),
+  name: z.string().min(1).describe("Full name (required)"),
+  title: z.string().optional().default("Untitled Resume").describe("Resume title (default: 'Untitled Resume')"),
+  email: z.string().email().optional().default("").describe("Email address (optional but recommended)"),
+  github: z.string().url().optional().describe("GitHub profile URL (optional)"),
+  description: z.string().optional().describe("Professional summary (optional)"),
+  workHistory: z.array(workHistorySchema).optional().default([]).describe("Array of work history entries (optional)"),
+  projects: z.array(projectSchema).optional().default([]).describe("Array of project entries (optional)"),
+  achievements: z.array(achievementSchema).optional().default([]).describe("Array of achievement entries (optional)"),
+};
+
+// Define tool metadata
+export const metadata: ToolMetadata = {
+  name: "update-resume",
+  description: "Update an existing resume with new data. Replaces all fields including work history, projects, and achievements.",
+  annotations: {
+    title: "Update Resume",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+// Tool implementation with API key validation
+export default requireApiKey(async (params: InferSchema<typeof schema>, validation) => {
+  try {
+    // First, check if the resume exists
+    const existingResume = await getResume(params.resumeId);
+
+    // Check if resume exists
+    if (!existingResume) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ error: "Resume not found" }, null, 2),
+          },
+        ],
+      };
+    }
+
+    // Verify that the resume belongs to the authenticated user
+    if (existingResume.userId !== validation.userId) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ error: "Access denied: You don't own this resume" }, null, 2),
+          },
+        ],
+      };
+    }
+
+    // Filter out empty entries from arrays (matching frontend behavior)
+    const filteredWorkHistory = (params.workHistory || []).filter((entry) =>
+      entry.companyName.trim().length > 0 ||
+      entry.role.trim().length > 0 ||
+      entry.dateOfWork.trim().length > 0 ||
+      entry.description.trim().length > 0
+    );
+
+    const filteredProjects = (params.projects || []).filter((entry) =>
+      entry.projectName.trim().length > 0 ||
+      (entry.projectUrl && entry.projectUrl.trim().length > 0) ||
+      entry.projectDescription.trim().length > 0
+    );
+
+    const filteredAchievements = (params.achievements || []).filter((entry) =>
+      entry.achievementName.trim().length > 0 ||
+      (entry.achievementUrl && entry.achievementUrl.trim().length > 0) ||
+      entry.achievementDescription.trim().length > 0
+    );
+
+    // Update the resume
+    await updateResume(params.resumeId, {
+      userId: validation.userId!,
+      title: params.title || "Untitled Resume",
+      name: params.name,
+      email: params.email || "",
+      github: params.github && params.github.trim().length > 0 ? params.github : undefined,
+      description: params.description && params.description.trim().length > 0 ? params.description : undefined,
+      workHistory: filteredWorkHistory,
+      projects: filteredProjects,
+      achievements: filteredAchievements,
+    });
+
+    // Fetch the updated resume to return to the user
+    const updatedResume = await getResume(params.resumeId);
+
+    // Return success message with the updated resume
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: true,
+              message: "Resume updated successfully",
+              resumeId: params.resumeId,
+              resume: updatedResume,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  } catch (error: any) {
+    // Handle any errors during resume update
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              error: "Failed to update resume",
+              details: error?.message || "Unknown error",
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  }
+});
+


### PR DESCRIPTION
Include create-resume.ts and update-resume.ts as externals and
register them in the webpack import map so dynamic tool loading
reflects the new endpoints.

- Export external modules for ../src/tools/create-resume.ts and
  ../src/tools/update-resume.ts in .xmcp/adapter/index.js bundle.
- Update the tools mapping order and add entries for the new
  create and update resume dynamic imports.
- Keep existing list/get/delete tool imports intact.

This ensures the runtime can dynamically import create and update
resume tools, enabling create/update resume functionality.