### PR TITLE
feat(deps): ✨ openrouter ai-sdk-provider and use openrouter chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@farcaster/jfs": "^0.0.6",
     "@farcaster/miniapp-sdk": "^0.1.10",
     "@google/genai": "^1.17.0",
+    "@openrouter/ai-sdk-provider": "^1.2.0",
     "ai": "^5.0.59",
     "dotenv": "^17.2.2",
     "drizzle-orm": "^0.44.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@google/genai':
         specifier: ^1.17.0
         version: 1.21.0(@modelcontextprotocol/sdk@1.18.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@openrouter/ai-sdk-provider':
+        specifier: ^1.2.0
+        version: 1.2.0(ai@5.0.59(zod@3.25.76))(zod@3.25.76)
       ai:
         specifier: ^5.0.59
         version: 5.0.59(zod@3.25.76)
@@ -982,6 +985,13 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@openrouter/ai-sdk-provider@1.2.0':
+    resolution: {integrity: sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ai: ^5.0.0
+      zod: ^3.24.1 || ^v4
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -5023,6 +5033,11 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@openrouter/ai-sdk-provider@1.2.0(ai@5.0.59(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      ai: 5.0.59(zod@3.25.76)
+      zod: 3.25.76
 
   '@opentelemetry/api@1.9.0': {}
 

--- a/src/app/api/(ai)/ai-proofread/route.ts
+++ b/src/app/api/(ai)/ai-proofread/route.ts
@@ -1,5 +1,9 @@
 import { streamText, convertToModelMessages, type UIMessage } from 'ai';
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 
+const openrouter = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
@@ -12,7 +16,7 @@ Maintain original formatting, bullet points, and line breaks. Do not add content
 Return ONLY the corrected text without explanations, notes, or quotes.`;
 
     const result = streamText({
-      model: 'meituan/longcat-flash-chat',
+      model: openrouter.chat('openai/gpt-5-nano'),
       system: systemMessage,
       messages: convertToModelMessages(messages),
     });

--- a/src/app/api/(ai)/ai-translate/route.ts
+++ b/src/app/api/(ai)/ai-translate/route.ts
@@ -1,5 +1,9 @@
 import { streamText, convertToModelMessages, type UIMessage } from 'ai';
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 
+const openrouter = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
@@ -20,7 +24,7 @@ Preserve the original meaning, tone, formatting, and code blocks. Keep bullet po
 Return ONLY the translated text without explanations, notes, or quotes.`;
 
     const result = streamText({
-      model: 'meituan/longcat-flash-chat',
+      model: openrouter.chat('openai/gpt-5-nano'),
       system: systemMessage,
       messages: convertToModelMessages(messages),
     });


### PR DESCRIPTION
Add @openrouter/ai-sdk-provider@^1.2.0 to package.json and pnpm-lock.
Initialize OpenRouter client (createOpenRouter) and switch ai routes to use
openrouter.chat('openai/gpt-5-nano') in ai-proofread and ai-translate endpoints.

- updates pnpm-lock.yaml with provider resolution and dependencies
- imports and configures createOpenRouter in both route handlers
- replaces model string with openrouter.chat(...) for streaming responses

This integrates OpenRouter as an additional AI provider; ensure OPENROUTER_API_KEY is set in env.